### PR TITLE
feat: adding layouts/groups/

### DIFF
--- a/layouts/groups/alpha.js
+++ b/layouts/groups/alpha.js
@@ -1,0 +1,10 @@
+require("../../helpers/keys")
+
+module.exports = {
+  qwer: [q, w, e, r, t, y, u, i, o, p],
+  asdf: [a, s, d, f, g, h, j, k, l],
+  zxcv: [z, x, c, v, b, n, m],
+  numrow: [num1, num2, num3, num4, num5, num6, num7, num8, num9, num0],
+  numrow_alts: [exclamation, at, hash, dollar, percent, caret, ampersand, asterisk, lparen, rparen],
+  frow: [f1, f2, f3, f4, f5, f6, f7, f8, f9, f10, f11, f12],
+}

--- a/layouts/groups/blanks.js
+++ b/layouts/groups/blanks.js
@@ -1,0 +1,28 @@
+require("../../helpers/keys")
+
+module.exports = {
+  x1: [xxx],
+  x2: [xxx, xxx],
+  x3: [xxx, xxx, xxx],
+  x4: [xxx, xxx, xxx, xxx],
+  x5: [xxx, xxx, xxx, xxx, xxx],
+  x6: [xxx, xxx, xxx, xxx, xxx, xxx],
+  x7: [xxx, xxx, xxx, xxx, xxx, xxx, xxx],
+  x8: [xxx, xxx, xxx, xxx, xxx, xxx, xxx, xxx],
+  x9: [xxx, xxx, xxx, xxx, xxx, xxx, xxx, xxx, xxx],
+  x10: [xxx, xxx, xxx, xxx, xxx, xxx, xxx, xxx, xxx, xxx],
+  x11: [xxx, xxx, xxx, xxx, xxx, xxx, xxx, xxx, xxx, xxx, xxx],
+  x12: [xxx, xxx, xxx, xxx, xxx, xxx, xxx, xxx, xxx, xxx, xxx, xxx],
+  _1: [___],
+  _2: [___, ___],
+  _3: [___, ___, ___],
+  _4: [___, ___, ___, ___],
+  _5: [___, ___, ___, ___, ___],
+  _6: [___, ___, ___, ___, ___, ___],
+  _7: [___, ___, ___, ___, ___, ___, ___],
+  _8: [___, ___, ___, ___, ___, ___, ___, ___],
+  _9: [___, ___, ___, ___, ___, ___, ___, ___, ___],
+  _10: [___, ___, ___, ___, ___, ___, ___, ___, ___, ___],
+  _11: [___, ___, ___, ___, ___, ___, ___, ___, ___, ___, ___],
+  _12: [___, ___, ___, ___, ___, ___, ___, ___, ___, ___, ___, ___],
+}

--- a/layouts/groups/index.js
+++ b/layouts/groups/index.js
@@ -1,0 +1,4 @@
+module.exports = {
+  blanks: require("./blanks"),
+  alpha: require("./alpha"),
+}

--- a/layouts/minivan.js
+++ b/layouts/minivan.js
@@ -1,41 +1,51 @@
 const keys = require("../helpers/keys")
 const minivan = require("../keyboards/minivan")
 
+const {
+  alpha: {
+    qwer, asdf, zxcv, numrow, numrow_alts,
+  },
+  blanks: {
+    x2, x3, x4, x6, x9, x10, x12,
+    _3, _4, _5, _6, _7, _8,
+  },
+} = require("./groups")
+
 const layers = {}
 
 layers._QWERTY = [
-  [tab, q, w, e, r, t, y, u, i, o, p, backspace],
-  [lt_esc, a, s, d, f, g, h, j, k, l, semicolon, quote],
-  [lshift, z, x, c, v, b, n, m, comma, dot, slash, minus],
+  [tab, ...qwer, backspace],
+  [lt_esc, ...asdf, semicolon, quote],
+  [lshift, ...zxcv, comma, dot, slash, minus],
   [lctrl, lalt, fn, lgui, raise, space, lower, rshift, grave, enter],
 ]
 
 layers._RAISE = [
-  [tilde, num1, num2, num3, num4, num5, num6, num7, num8, num9, num0, backspace],
-  [___, f1, f2, f3, f4, f5, f6, xxx, xxx, xxx, xxx, backslash],
-  [___, f7, f8, f9, f10, f11, f12, xxx, xxx, xxx, xxx, ___],
-  [___, ___, ___, ___, ___, lshift, next, vold, volu, play],
+  [tilde, ...numrow, backspace],
+  [___, f1, f2, f3, f4, f5, f6, ...x4, backslash],
+  [___, f7, f8, f9, f10, f11, f12, ...x4, ___],
+  [..._5, lshift, next, vold, volu, play],
 ]
 
 layers._LOWER = [
-  [tilde, exclamation, at, hash, dollar, percent, caret, ampersand, asterisk, lparen, rparen, backspace],
-  [del, ___, ___, ___, ___, ___, ___, xxx, xxx, lcurlybrace, rcurlybrace, pipe],
-  [___, xxx, xxx, xxx, xxx, xxx, xxx, xxx, xxx, xxx, xxx, ___],
-  [___, ___, ___, ___, xxx, xxx, xxx, xxx, xxx, xxx],
+  [tilde, ...numrow_alts, backspace],
+  [del, ..._6, ...x2, lcurlybrace, rcurlybrace, pipe],
+  [___, ...x10, ___],
+  [..._4, ...x6],
 ]
 
 layers._ALT = [
-  [___, ___, ___, ___, ___, ___, ___, ___, up, lcurlybrace, rcurlybrace, equal],
-  [___, ___, ___, ___, ___, ___, ___, left, down, right, xxx, grave],
-  [___, ___, ___, caps, ___, ___, ___, ___, ___, ___, ___, backslash],
-  [___, ___, ___, ___, ___, ___, ___, ___, vold, volu],
+  [..._8, up, lcurlybrace, rcurlybrace, equal],
+  [..._7, left, down, right, xxx, grave],
+  [..._3, caps, ..._7, backslash],
+  [..._8, vold, volu],
 ]
 
 layers._FN = [
-  [xxx, xxx, xxx, xxx, xxx, xxx, xxx, xxx, xxx, xxx, xxx, xxx],
-  [xxx, xxx, xxx, xxx, xxx, xxx, xxx, xxx, xxx, xxx, xxx, xxx],
-  [xxx, xxx, xxx, xxx, xxx, xxx, xxx, xxx, xxx, xxx, xxx, xxx],
-  [xxx, xxx, xxx, xxx, xxx, xxx, xxx, xxx, xxx, reset],
+  x12,
+  x12,
+  x12,
+  [...x9, reset],
 ]
 
 module.exports = {

--- a/layouts/roadkit-macropad.js
+++ b/layouts/roadkit-macropad.js
@@ -1,5 +1,6 @@
 const keys = require("../helpers/keys")
 const roadkit = require("../keyboards/roadkit")
+const { x2, x3, x4 } = require("./groups/blanks")
 
 const layers = {}
 
@@ -11,10 +12,10 @@ layers[0] = [
 ]
 
 layers._RAISE = [
-  [esc, xxx, xxx, kp_asterisk],
-  [xxx, xxx, xxx, kp_slash],
-  [xxx, xxx, xxx, xxx],
-  [xxx, xxx, xxx, xxx],
+  [esc, ...x2, kp_asterisk],
+  [...x3, kp_slash],
+  x4,
+  x4,
 ]
 
 module.exports = {


### PR DESCRIPTION
  - adding this area for key groups shared across layouts
  - adding "blanks" groups
  - adding "alpha" groups
  - updating minivan and roadkit layouts to use these groups*

  *these layouts were updated to use the groups as much as possible, but
  in my opinion it ended up making the layout file harder to understand,
  and possibly more challenging to modify. there is probably a balance
  to be achieved ultimately, but this does make for some very quick
  layout generation when re-using common layout pieces.